### PR TITLE
Quote API_URL in workflow

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -22,6 +22,6 @@ jobs:
       run: |
        echo ${{github.event.release.tag_name}} | grep -e 'v20[0-9][0-9][0-1][0-9][0-9][0-9]'
        echo ${{secrets.JENKINS_BOT_PASS}} | kinit ${{secrets.PRINCIPAL}}
-       curl -X POST -k --negotiate -u : ${{secrets.API_URL}} -H 'Content-Type: application/x-www-form-urlencoded' -d 'DELPHESO2_TAG=${{github.event.release.tag_name}}'
+       curl -X POST -k --negotiate -u : '${{secrets.API_URL}}' -H 'Content-Type: application/x-www-form-urlencoded' -d 'DELPHESO2_TAG=${{github.event.release.tag_name}}'
        klist
        kdestroy


### PR DESCRIPTION
It has special characters that might throw bash off.